### PR TITLE
aboutのアンカーリンク修正

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,7 +21,7 @@
       <div class="offcanvas-body">
         <ul id="navbar" class="navbar-nav text-uppercase justify-content-end align-items-center flex-grow-1 pe-3">
           <li class="nav-item">
-            <%= link_to "#about-us", class: "nav-link me-4" do %>
+            <%= link_to "#{root_url}#about-us", class: "nav-link me-4" do %>
               <i class="fa-solid fa-comment"></i> About
             <% end %>
           </li>


### PR DESCRIPTION
ヘッダーにあるaboutがアンカーリンク#about_usを付与するだけだっためトップ以外では機能しなかった。
そのため#{root_url}を付けて対応