### PR TITLE
Remove duplicate importmap application pin

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,6 +3,5 @@
 pin 'application', preload: true
 pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true
 pin '@hotwired/stimulus', to: 'stimulus.min.js', preload: true
-pin 'application', to: 'controllers/application.js'
 pin 'hello_controller', to: 'controllers/hello_controller.js'
 pin_all_from 'app/javascript/controllers', under: 'controllers'


### PR DESCRIPTION
## Summary
- remove extra `pin 'application'` directive in `importmap.rb`

## Testing
- `bin/rails importmap:inspect` *(fails: rbenv: version `ruby-3.1.4` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68477cb8e51483299af21357d8c7d6f1