### PR TITLE
Fix typo in helper method name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,14 +19,14 @@ module ApplicationHelper
       reverse: true,
       description: 'このアプリは、お部屋のインテリアにぴったりなポスターや絵画を見つけるお手伝いをします。
       独自のマッチングシステムを用いて空間に合わせたアート作品を提案することで、統一感のある理想の部屋作りをサポート。ポスターであなたの部屋をもっとおしゃれな空間に変えてみませんか？',
-      og: defalut_og,
+      og: default_og,
       twitter: default_twitter_card
     }
   end
   
   private
   
-  def defalut_og
+  def default_og
     {
       site_name: :site,
       title: :title,


### PR DESCRIPTION
## Summary
- rename `defalut_og` to `default_og`
- update the call in `default_meta_tags`

## Testing
- `bundle exec rspec` *(fails: rbenv version `ruby-3.1.4` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68477cbd17a8832999735e3a1c69d855